### PR TITLE
Fix: expose the error message with the error object

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -28,6 +28,7 @@ const DEFAULT_OPTIONS: Readonly<ClientOptions> = Object.freeze({
 });
 
 class ApiError extends Error {
+  message: string;
   code?: string;
   status?: number;
   headers: HttpHeaders;
@@ -38,8 +39,9 @@ class ApiError extends Error {
     status?: number,
     headers: HttpHeaders = {},
   ) {
-    super(message);
+    super();
 
+    this.message = message;
     this.code = code;
     this.status = status;
     this.headers = headers;


### PR DESCRIPTION
For backwards compatibility, return just the error message and not the entire error object.