### PR TITLE
Fix User-Agent; add X-User-Application

### DIFF
--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -78,8 +78,16 @@ describe('Client', () => {
         client.init('id', 'key');
         expect(
           client.httpClient?.defaults.headers.common['User-Agent'],
+        ).toMatch(/^swell-node-http@.+$/);
+      });
+
+      test('sets default x-user-application header', () => {
+        client.init('id', 'key');
+
+        expect(
+          client.httpClient?.defaults.headers.common['X-User-Application'],
         ).toEqual(
-          `${process.env.npm_package_name} (${process.env.npm_package_version})`,
+          `${process.env.npm_package_name}@${process.env.npm_package_version}`,
         );
       });
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,6 +1,6 @@
 import * as axios from 'axios';
 import { CookieJar } from 'tough-cookie';
-import { HttpCookieAgent, HttpsCookieAgent } from 'http-cookie-agent/http'; 
+import { HttpCookieAgent, HttpsCookieAgent } from 'http-cookie-agent/http';
 
 export enum HttpMethod {
   get = 'get',
@@ -20,6 +20,15 @@ export interface ClientOptions {
   timeout?: number;
   headers?: HttpHeaders;
 }
+
+const MODULE_VERSION: string = (({ name, version }) => {
+  return `${name}@${version}`;
+})(require('../package.json')); // eslint-disable-line @typescript-eslint/no-var-requires
+
+const USER_APP_VERSION: string | undefined =
+  process.env.npm_package_name && process.env.npm_package_version
+    ? `${process.env.npm_package_name}@${process.env.npm_package_version}`
+    : undefined;
 
 const DEFAULT_OPTIONS: Readonly<ClientOptions> = Object.freeze({
   url: 'https://api.swell.store',
@@ -111,7 +120,8 @@ export class Client {
         common: {
           ...headers,
           'Content-Type': 'application/json',
-          'User-Agent': `${process.env.npm_package_name} (${process.env.npm_package_version})`,
+          'User-Agent': MODULE_VERSION,
+          'X-User-Application': USER_APP_VERSION,
           Authorization: `Basic ${authToken}`,
         },
       },


### PR DESCRIPTION
Fix user-agent tracking.

- `User-Agent` header is resolved from package name and version defined in `package.json` (previously this came from process.env).
- `X-User-Application` header is resolved from `process.env.npm_package_*`

Also standardized User-Agent format to be: `name@version` (previously this was 'name version')

