### PR TITLE
Fixed using client in singleton mode; update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 ## Connect
 
 ```javascript
-const swell = require('swell-node-http');
+const { swell } = require('swell-node-http');
 
 swell.init('my-store', 'secret-key');
 ```
@@ -17,10 +17,10 @@ swell.init('my-store', 'secret-key');
 To connect to multiple stores in the same process, use `swell.createClient()`:
 
 ```javascript
-const swell = require('swell-node-http');
+const { swell } = require('swell-node-http');
 
-const store1 = swell.createClient('my-store-1', 'secret-key-1');
-const store2 = swell.createClient('my-store-2', 'secret-key-2');
+const client1 = swell.create('my-store-1', 'secret-key-1');
+const client2 = swell.create('my-store-2', 'secret-key-2');
 ```
 
 ## Usage

--- a/src/client.ts
+++ b/src/client.ts
@@ -67,14 +67,6 @@ export class Client {
   options: ClientOptions;
   httpClient?: axios.AxiosInstance;
 
-  static create(
-    clientId: string,
-    clientKey: string,
-    options: ClientOptions = {},
-  ): Client {
-    return new Client(clientId, clientKey, options);
-  }
-
   constructor(
     clientId?: string,
     clientKey?: string,
@@ -85,6 +77,17 @@ export class Client {
     if (clientId) {
       this.init(clientId, clientKey, options);
     }
+  }
+
+  /**
+   * Convenience method to create a new client instance from a singleton instance.
+   */
+  create(
+    clientId: string,
+    clientKey: string,
+    options: ClientOptions = {},
+  ): Client {
+    return new Client(clientId, clientKey, options);
   }
 
   init(clientId?: string, clientKey?: string, options?: ClientOptions): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { Client } from './client';
 
-export default new Client();
-export const createClient = Client.create;
+// Singleton
+export const swell = new Client();
 
 export * from './client';


### PR DESCRIPTION
- Fixed so that both singleton (`swell.init()`) and multi-instance (`swell.create()`) both work 
- Updated README
