### PR TITLE
Feature: Implement retries mechanism

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,11 +11,13 @@
       "dependencies": {
         "axios": "^1.6.2",
         "http-cookie-agent": "^5.0.4",
+        "retry": "^0.13.1",
         "tough-cookie": "^4.1.3"
       },
       "devDependencies": {
         "@types/jest": "^29.5.11",
         "@types/node": "^14.14.31",
+        "@types/retry": "^0.12.5",
         "@types/tough-cookie": "^4.0.5",
         "@typescript-eslint/eslint-plugin": "^6.18.1",
         "@typescript-eslint/parser": "^6.18.1",
@@ -1527,6 +1529,12 @@
       "version": "14.18.63",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
       "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
+      "dev": true
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.5.tgz",
+      "integrity": "sha512-3xSjTp3v03X/lSQLkczaN9UIEwJMoMCA1+Nb5HfbJEQWogdeQIyVtTvxPXDQjZ5zws8rFQfVfRdz03ARihPJgw==",
       "dev": true
     },
     "node_modules/@types/semver": {
@@ -4965,6 +4973,14 @@
         "node": ">=10"
       }
     },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
@@ -6922,6 +6938,12 @@
       "version": "14.18.63",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
       "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
+      "dev": true
+    },
+    "@types/retry": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.5.tgz",
+      "integrity": "sha512-3xSjTp3v03X/lSQLkczaN9UIEwJMoMCA1+Nb5HfbJEQWogdeQIyVtTvxPXDQjZ5zws8rFQfVfRdz03ARihPJgw==",
       "dev": true
     },
     "@types/semver": {
@@ -9382,6 +9404,11 @@
       "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.2.tgz",
       "integrity": "sha512-X2UW6Nw3n/aMgDVy+0rSqgHlv39WZAlZrXCdnbyEiKm17DSqHX4MmQMaST3FbeWR5FTuRcUwYAziZajji0Y7mg==",
       "dev": true
+    },
+    "retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="
     },
     "reusify": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -26,11 +26,13 @@
   "dependencies": {
     "axios": "^1.6.2",
     "http-cookie-agent": "^5.0.4",
+    "retry": "^0.13.1",
     "tough-cookie": "^4.1.3"
   },
   "devDependencies": {
     "@types/jest": "^29.5.11",
     "@types/node": "^14.14.31",
+    "@types/retry": "^0.12.5",
     "@types/tough-cookie": "^4.0.5",
     "@typescript-eslint/eslint-plugin": "^6.18.1",
     "@typescript-eslint/parser": "^6.18.1",

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -199,6 +199,7 @@ describe('Client', () => {
     test('handle zero retries by default', async () => {
       const client = new Client('id', 'key');
 
+      // Simulate server failure on first 2 attempts and success on the third
       let retryCounter = 0;
       mock.onGet('/products/:count').reply(() => {
         retryCounter++;
@@ -216,6 +217,7 @@ describe('Client', () => {
     test('handle retries option', async () => {
       const client = new Client('id', 'key', { retries: 3 });
 
+      // Simulate server failure on first 2 attempts and success on the third
       let retryCounter = 0;
       mock.onGet('/products/:count').reply(() => {
         retryCounter++;
@@ -236,6 +238,7 @@ describe('Client', () => {
     test('handle return error if response not received after retries', async () => {
       const client = new Client('id', 'key', { retries: 3 });
 
+      // Simulate server failure on first 4 attempts and success on the fifth
       let retryCounter = 0;
       mock.onGet('/products/:count').reply(() => {
         retryCounter++;

--- a/src/client.ts
+++ b/src/client.ts
@@ -37,7 +37,7 @@ const DEFAULT_OPTIONS: Readonly<ClientOptions> = Object.freeze({
   verifyCert: true,
   version: 1,
   headers: {},
-  retries: 0,
+  retries: 0, // 0 => no retries
 });
 
 class ApiError extends Error {

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,4 +1,5 @@
 import * as axios from 'axios';
+import * as retry from 'retry';
 import { CookieJar } from 'tough-cookie';
 import { HttpCookieAgent, HttpsCookieAgent } from 'http-cookie-agent/http';
 
@@ -19,6 +20,7 @@ export interface ClientOptions {
   version?: number;
   timeout?: number;
   headers?: HttpHeaders;
+  retries?: number;
 }
 
 const MODULE_VERSION: string = (({ name, version }) => {
@@ -35,6 +37,7 @@ const DEFAULT_OPTIONS: Readonly<ClientOptions> = Object.freeze({
   verifyCert: true,
   version: 1,
   headers: {},
+  retries: 0,
 });
 
 class ApiError extends Error {
@@ -163,21 +166,36 @@ export class Client {
     url: string,
     data?: unknown,
   ): Promise<T> {
-    if (this.httpClient === null) {
-      throw new Error('Swell API client not initialized');
-    }
-
     // Prepare url and data for request
     const requestParams = transformRequest(method, url, data);
 
-    let response;
-    try {
-      response = await this.httpClient.request<T>(requestParams);
-    } catch (error) {
-      throw transformError(error);
-    }
+    return new Promise((resolve, reject) => {
+      const { retries } = this.options;
 
-    return transformResponse(response).data;
+      const operation = retry.operation({
+        retries,
+        minTimeout: 20,
+        maxTimeout: 100,
+        factor: 1,
+        randomize: false,
+      });
+
+      operation.attempt(async () => {
+        if (this.httpClient === null) {
+          return reject(new Error('Swell API client not initialized'));
+        }
+
+        try {
+          const response = await this.httpClient.request<T>(requestParams);
+          resolve(transformResponse(response).data);
+        } catch (error) {
+          if (operation.retry(error as Error)) {
+            return;
+          }
+          reject(transformError(operation.mainError()));
+        }
+      });
+    });
   }
 }
 


### PR DESCRIPTION
## Description

Sometimes requests could fail because of network, in this case we can add option `retries` (default 0), which tries to resend request n-times and throws error is all attempts failed.

## Testing

To simulate bad network I tried to close socket with 20% chance

### Before

https://github.com/swellstores/swell-node-http/assets/136735357/e182ceef-1706-4cf5-94b8-315edaa388da

### After

https://github.com/swellstores/swell-node-http/assets/136735357/f976a628-3156-41a9-a152-175481c2049e

Also added unit tests