### PR TITLE
Feature: Improve retries mechanism  

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -194,14 +194,15 @@ export class Client {
         } catch (error) {
           // Attempt retry if we encounter a timeout or connection error
           const code = axios.isAxiosError(error) ? error?.code : null;
-          if (code && !RETRY_CODES.has(code)) {
-            return reject(transformError(operation.mainError()));
-          }
 
-          if (operation.retry(error as Error)) {
+          if (
+            code &&
+            RETRY_CODES.has(code) &&
+            operation.retry(error as Error)
+          ) {
             return;
           }
-          reject(transformError(operation.mainError()));
+          reject(transformError(error));
         }
       });
     });

--- a/src/client.ts
+++ b/src/client.ts
@@ -62,7 +62,7 @@ class ApiError extends Error {
 }
 
 // We should retry request only in case of timeout or disconnect
-const RETRY_CODES = ['ECONNABORTED', 'ECONNREFUSED'];
+const RETRY_CODES = new Set(['ECONNABORTED', 'ECONNREFUSED']);
 
 /**
  * Swell API Client.
@@ -192,8 +192,9 @@ export class Client {
           const response = await this.httpClient.request<T>(requestParams);
           resolve(transformResponse(response).data);
         } catch (error) {
+          // Attempt retry if we encounter a timeout or connection error
           const code = axios.isAxiosError(error) ? error?.code : null;
-          if (code && !RETRY_CODES.includes(code)) {
+          if (code && !RETRY_CODES.has(code)) {
             return reject(transformError(operation.mainError()));
           }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -193,11 +193,11 @@ export class Client {
           resolve(transformResponse(response).data);
         } catch (error) {
           const code = axios.isAxiosError(error) ? error?.code : null;
-          if (
-            code &&
-            RETRY_CODES.includes(code) &&
-            operation.retry(error as Error)
-          ) {
+          if (code && !RETRY_CODES.includes(code)) {
+            return reject(transformError(operation.mainError()));
+          }
+
+          if (operation.retry(error as Error)) {
             return;
           }
           reject(transformError(operation.mainError()));


### PR DESCRIPTION
### Description

`swell-node-http` has a retry mechanism, but it works even when `swell-api` returned `500` or `404` status. To improve it we can add checking response status code and retry it only in case of `ECONNREFUSED` and `ECONNABORTED` statuses.

![image](https://github.com/user-attachments/assets/8bdfa0c5-597f-46cf-8299-c5b4314a0e24)

![image](https://github.com/user-attachments/assets/de562a48-fb55-46fb-b29f-0d1510b3341c)

### Demo

Simulating situation when 20% of requests are failing with closing connection:

https://github.com/user-attachments/assets/4241f574-897e-4fbb-aaf4-e6bccac0d7b8

