### PR TITLE
Renamed create => createClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ To connect to multiple stores in the same process, use `swell.createClient()`:
 ```javascript
 const { swell } = require('swell-node-http');
 
-const client1 = swell.create('my-store-1', 'secret-key-1');
-const client2 = swell.create('my-store-2', 'secret-key-2');
+const client1 = swell.createClient('my-store-1', 'secret-key-1');
+const client2 = swell.createClient('my-store-2', 'secret-key-2');
 ```
 
 ## Usage

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -20,7 +20,34 @@ describe('Client', () => {
       expect(client.options.timeout).toEqual(1000);
       expect(client.httpClient).toBeDefined();
     });
-  });
+  }); // describe: #constructor
+
+  describe('#createClient', () => {
+    let client: Client;
+
+    beforeEach(() => {
+      client = new Client();
+    });
+
+    it('instantiates multiple clients', () => {
+      const one = client.createClient('id', 'key1');
+      expect(
+        one instanceof Client,
+      ).toBe(true);
+      expect(
+        one.httpClient?.defaults.headers.common['X-Header'],
+      ).toBe(undefined);
+
+      const two = client.createClient('id', 'key2', { headers: { 'X-Header': 'Foo' } });
+      expect(
+        two instanceof Client,
+      ).toBe(true);
+      expect(
+        two.httpClient?.defaults.headers.common['X-Header'],
+      ).toEqual('Foo');
+
+    });
+  }); // describe: #createClient
 
   describe('#init', () => {
     let client: Client;

--- a/src/client.ts
+++ b/src/client.ts
@@ -91,7 +91,7 @@ export class Client {
   /**
    * Convenience method to create a new client instance from a singleton instance.
    */
-  create(
+  createClient(
     clientId: string,
     clientKey: string,
     options: ClientOptions = {},


### PR DESCRIPTION
For backwards compatibility, make the SDK interface the same as `swell-node`.

- Renames `Client#create` to `Client#createClient`. (BREAKING CHANGE)
- Updated README usage example
- Add test for `Client#createClient`